### PR TITLE
Fixing typename middleware so it doesn't add an item into a empty col…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ that provides client-side solution for [GraphQL](https://graphql.org/) and re-fr
 Think of [apollo-client](https://github.com/apollographql/apollo-client), but tailored specifically for re-frame.
  
 ## Installation
-Add `[district0x/district-ui-graphql "1.0.5"]` into your project.clj  
+Add `[district0x/district-ui-graphql "1.0.6"]` into your project.clj  
 Include `[district.ui.graphql]` in your CLJS file, where you use `mount/start`
   
 ## Introduction

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-graphql "1.0.5"
+(defproject district0x/district-ui-graphql "1.0.6"
   :description "district UI module for GraphQL integration"
   :url "https://github.com/district0x/district-ui-graphql"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/graphql/middleware/typenames.cljs
+++ b/src/district/ui/graphql/middleware/typenames.cljs
@@ -16,7 +16,7 @@
 
       (and (instance? (aget js/GraphQL "GraphQLList") return-type)
            (instance? (aget js/GraphQL "GraphQLObjectType") (aget return-type "ofType")))
-      (js/Array. (js/Object.))
+      (js/Array.)
 
       :else nil)))
 


### PR DESCRIPTION
Fixing typename middleware so it doesn't add an item into a empty collection.

@madvas not sure why that extra object was there but when the collection is empty it is adding one element. 
After removing it everything works fine in memefactory so doesn't seem to be breaking anything.