### PR TITLE
Fix query->clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject district0x/district-ui-graphql "1.0.14-SNAPSHOT"
+(defproject district0x/district-ui-graphql "1.0.15-SNAPSHOT"
   :description "district UI module for GraphQL integration"
   :url "https://github.com/district0x/district-ui-graphql"
   :license {:name "Eclipse Public License"

--- a/src/district/ui/graphql/events.cljs
+++ b/src/district/ui/graphql/events.cljs
@@ -107,16 +107,11 @@
 (reg-event-fx
   ::mutation-success
   interceptors
-  (fn [{:keys [:db]} [{:keys [:on-success]} resp {:keys [:query :query-str :variables]}]]
-    (let [config (queries/config db)]
-      {:dispatch [::normalize-response resp {:query-clj (utils/query->clj
-                                                          query
-                                                          (:schema config)
-                                                          (merge config
-                                                                 {:variables variables}))
-                                             :query-str query-str
-                                             :variables variables
-                                             :on-normalization-success on-success}]})))
+  (fn [{:keys [:db]} [{:keys [:on-success]} resp {:keys [:query :query-str :variables :query-clj]}]]
+    {:dispatch [::normalize-response resp {:query-clj query-clj
+                                           :query-str query-str
+                                           :variables variables
+                                           :on-normalization-success on-success}]}))
 
 
 (reg-event-fx


### PR DESCRIPTION
query->clj uses the "visit" method of graphql to navigate through the graph. When the function of this method return the boolean "false", it means the rest of the node is ignored. That collides when trying to set the BooleanValue "false".
To solve this, the placeholder ":false" is returned and converted to "false" afterwards.

Also it has been added support for ObjectField and fix ObjectValue so it properly handles inner maps as inputs.